### PR TITLE
refactor: add a new base webhook view

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python Debugger: Django",
+            "type": "debugpy",
+            "purpose": ["debug-test"],
+            "request": "launch",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "autoStartBrowser": false,
+            "program": "${workspaceFolder}/manage.py",
+            "justMyCode": true
+        }
+    ]
+}

--- a/src/django_cloudevents/_compat.py
+++ b/src/django_cloudevents/_compat.py
@@ -9,6 +9,11 @@ if sys.version_info < (3, 12):
 else:
     from typing import override
 
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from warnings import deprecated
+
 if django.VERSION >= (5, 0):
     Signal = _DjangoSignal
 else:
@@ -20,5 +25,6 @@ else:
 
 __all__ = [
     "Signal",
+    "deprecated",
     "override",
 ]

--- a/src/django_cloudevents/views.py
+++ b/src/django_cloudevents/views.py
@@ -11,6 +11,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
+from ._compat import deprecated
 from .conf import settings
 from .processors import InvalidEventProcessorError, event_processors
 from .signals import cloudevent_received
@@ -53,6 +54,7 @@ class CloudEventWebhookView(View):
         return _cloudevent_response_meta(response)
 
 
+@deprecated("Use a view custom view inheriting from CloudEventWebhookView")
 @method_decorator(csrf_exempt, name="dispatch")
 class WebhookView(CloudEventWebhookView):
     http_method_names: list[str] = ["post", "options"]  # noqa: RUF012

--- a/src/django_cloudevents/views.py
+++ b/src/django_cloudevents/views.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import inspect
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 from cloudevents.http import from_http
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseBase
 from django.http.request import validate_host
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -15,11 +16,45 @@ from .processors import InvalidEventProcessorError, event_processors
 from .signals import cloudevent_received
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from django.http import HttpRequest
 
 
+class CloudEventWebhookView(View):
+    def options(  # type: ignore[override]
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponseBase | Awaitable[HttpResponseBase]:
+        def _cloudevent_response_meta(response: HttpResponseBase) -> HttpResponseBase:
+            if "WebHook-Request-Origin" in request.headers and validate_host(
+                request.headers["WebHook-Request-Origin"],
+                settings.webhook_allowed_origins,
+            ):
+                response["WebHook-Allowed-Origin"] = (
+                    "*" if settings.webhook_allow_all_origins else request.headers["WebHook-Request-Origin"]
+                )
+
+                if settings.webhook_allowed_rate:
+                    response["WebHook-Allowed-Rate"] = str(settings.webhook_allowed_rate)
+                elif "WebHook-Request-Rate" in request.headers:
+                    response["WebHook-Allowed-Rate"] = request.headers["WebHook-Request-Rate"]
+
+            return response
+
+        response: HttpResponseBase | Awaitable[HttpResponseBase] = super().options(request, *args, **kwargs)
+
+        if inspect.isawaitable(response):
+
+            async def func() -> HttpResponseBase:
+                return _cloudevent_response_meta(await response)
+
+            return func()
+
+        return _cloudevent_response_meta(response)
+
+
 @method_decorator(csrf_exempt, name="dispatch")
-class WebhookView(View):
+class WebhookView(CloudEventWebhookView):
     http_method_names: list[str] = ["post", "options"]  # noqa: RUF012
 
     async def post(self, request: HttpRequest) -> HttpResponse:
@@ -35,20 +70,3 @@ class WebhookView(View):
             if not response:
                 return HttpResponse(status=HTTPStatus.ACCEPTED)
             return response
-
-    async def options(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:  # type: ignore[override]
-        response = await super().options(request, *args, **kwargs)  # type: ignore[misc]
-
-        if "WebHook-Request-Origin" in request.headers and validate_host(
-            request.headers["WebHook-Request-Origin"],
-            settings.webhook_allowed_origins,
-        ):
-            response["WebHook-Allowed-Origin"] = (
-                "*" if settings.webhook_allow_all_origins else request.headers["WebHook-Request-Origin"]
-            )
-
-            if settings.webhook_allowed_rate:
-                response["WebHook-Allowed-Rate"] = str(settings.webhook_allowed_rate)
-            elif "WebHook-Request-Rate" in request.headers:
-                response["WebHook-Allowed-Rate"] = request.headers["WebHook-Request-Rate"]
-        return response


### PR DESCRIPTION
Add a base webhook view. This is to better align to the webhook spec.

Algo, deprecate the old webhook view that use the processors. While a nice touch, it forces applications to use a specific pattern.

Maybe the processors themselves will eventually be deprecated, since there is nothing on the specs on how to actually process the CloudEvents